### PR TITLE
roll templates and user abilities

### DIFF
--- a/D&D_BECM/BDnDSheet.css
+++ b/D&D_BECM/BDnDSheet.css
@@ -99,6 +99,9 @@ body.sheet-darkmode .charsheet {
 .sheet-rolltemplate-5eDefault .sheet-rt-header {
 	background-color: var(--rt-header-background);
 	background-image: linear-gradient(rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0));
+	border-radius: 5px 5px 0px 0px;
+	-moz-border-radius: 5px 5px 0px 0px;
+	-webkit-border-radius: 5px 5px 0px 0px;
 	box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 	-moz-box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
 	-webkit-box-shadow: 0 2px 0 rgba(0, 0, 0, 0.3);
@@ -740,6 +743,14 @@ textarea,
 
 .sheet-border-top {
 	border-top: 1px solid var(--border);
+}
+
+.sheet-resizev {
+    resize: vertical;
+}
+
+.sheet-background-0 {
+    background: 0;
 }
 
 input[type="number"],

--- a/D&D_BECM/BDnDSheet.css
+++ b/D&D_BECM/BDnDSheet.css
@@ -75,9 +75,9 @@ body.sheet-darkmode .charsheet {
 }
 
 .sheet-rolltemplate-5eDefault.sheet-rolltemplate-darkmode {
-	--background: var(--dark-surface1);
-	--rt-even-row-background: var(--dark-surface2);
-	--rt-text-color: var(--dark-primarytext);
+	--background: #1f1f1f;
+	--rt-even-row-background: #353535;
+	--rt-text-color: #e6e6e6;
 }
 
 /* Roll Template */
@@ -214,11 +214,28 @@ body.sheet-darkmode .charsheet {
 	border-top: 1px dotted var(--border);
 }
 
+.sheet-rolltemplate-5eDefault .sheet-rt-card .inlinerollresult {
+    background-color: var(--el-color-black);
+    border-color: var(--el-color-black);
+    color: var(--el-color-white);
+}
+
+.sheet-rolltemplate-5eDefault .sheet-rt-card .inlinerollresult.fullcrit {
+    border-color: var(--el-color-success);
+}
+
+.sheet-rolltemplate-5eDefault .sheet-rt-card .inlinerollresult.fullfail {
+    border-color: var(--el-color-danger);
+}
+
 /* Roll Template End-ish */
 
 .charsheet {
 	padding: 0px !important;
 }
+
+/*** ROLL TEMPLATE STYLING ENDS HERE **/
+
 
 /* overall wrapper to fix moving width issues with overflow on hidden sections */
 .sheet-overall-wrapper {

--- a/D&D_BECM/BDnDSheet.html
+++ b/D&D_BECM/BDnDSheet.html
@@ -745,6 +745,28 @@
 				</div>
 			</div>
 		</div>
+		<div class="sheet-row sheet-padt">
+			<h4 class="sheet-col-1 sheet-center">Custom Abilities <span class="sheet-pictos">W</span></h4>
+			<div class="sheet-row sheet-sub-header sheet-small-label sheet-center">
+				<div class="sheet-col-3-16 sheet-padl sheet-padr sheet-right">Name</div>
+				<div class="sheet-col-3-4 sheet-center">Description</div>
+				<div class="sheet-col-1-16 sheet-center">Roll</div>
+			</div>
+			<fieldset class="repeating_customabilities">
+				<div class="sheet-row sheet-padb sheet-padt">
+					<div class="sheet-col-3-16 sheet-padl sheet-padr">
+						<input class="sheet-center" name="attr_customabilityname" placeholder="Name" type="text">
+					</div>
+					<div class="sheet-col-3-4">
+						<textarea class="sheet-background-0 sheet-center sheet-resizev sheet-small-textarea" name="attr_customabilitydescription" placeholder="Describe your custom ability here."></textarea>
+					</div>
+					<div class="sheet-col-1-16 sheet-center">
+						<button type="roll" class="sheet-roll" name="roll_displaycustomability" value="&{template:5eDefault} {{ability=1}} {{title=@{customabilityname}}} {{subheader=@{character_name} Custom Ability}} {{freetext=@{customabilitydescription}}}"></button>
+					</div>
+					<hr/>
+				</div>
+			</fieldset>
+		</div>
 	</div>
 	<!--Combat-->
 	<div class="sheet-section-combat">


### PR DESCRIPTION
### Proposed Changes

- Updates dnd becmi roll templates to support dark mode
  - Adds CSS rules to use the defined dark mode colours for the roll template row backgrounds and text
  - Updates some existing CSS rules to use defined colours rather than similar hard-coded colours
  - Adds CSS rules to ensure the inline roll results are coloured in a specific manner to ensure readability
- Adds repeating custom abilities section
  - Adds a repeating section in the Class tab for custom abilities
    - A name, description, and roll field allow for naming, describing, and logging the ability to the chat
  - Adds a sheet-resizev css rule to add the vertical resizing behaviour
  - Adds a sheet-background-0 css rule to allow for assigning a clear background to any element